### PR TITLE
Fix normalization arrays in YOLOv8 pose config

### DIFF
--- a/configs/yolov8_pose.yaml
+++ b/configs/yolov8_pose.yaml
@@ -4,8 +4,8 @@ imgsz: 640
 input_name: "images"
 letterbox_value: 114
 normalize: true
-mean: [0.0]
-std: [1.0]
+mean: [0.0, 0.0, 0.0]
+std: [1.0, 1.0, 1.0]
 
 # PTQ-Static (ORT)
 per_channel: true


### PR DESCRIPTION
## Summary
- expand YAML mean and std arrays to RGB channels

## Testing
- `python scripts/eval_compare_fp32_int8.py --cfg configs/yolov8_pose.yaml --fp32 onnx/yolov8n-pose-fp32.onnx --int8 onnx/yolov8n-pose-fp32.onnx --valdir ultralytics/ultralytics/assets` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68aa9a710e5883238d68180d8d0b96b8