### PR TITLE
Fix mean/std handling in eval script

### DIFF
--- a/scripts/eval_compare_fp32_int8.py
+++ b/scripts/eval_compare_fp32_int8.py
@@ -14,7 +14,13 @@ def preprocess(path, imgsz, lb_val, norm, mean, std):
     img = canvas[:, :, ::-1].transpose(2,0,1).astype(np.float32)
     if norm:
         img /= 255.0
-        img = (img - np.array(mean).reshape(1,3,1,1)) / np.array(std).reshape(1,3,1,1)
+        mean_arr = np.array(mean, dtype=np.float32).reshape(-1, 1, 1)
+        std_arr = np.array(std, dtype=np.float32).reshape(-1, 1, 1)
+        if mean_arr.shape[0] != img.shape[0]:
+            mean_arr = np.resize(mean_arr, (img.shape[0], 1, 1))
+        if std_arr.shape[0] != img.shape[0]:
+            std_arr = np.resize(std_arr, (img.shape[0], 1, 1))
+        img = (img - mean_arr) / std_arr
     return img
 
 def run_session(onnx_path, input_name=None):

--- a/scripts/eval_compare_fp32_int8.py
+++ b/scripts/eval_compare_fp32_int8.py
@@ -14,6 +14,8 @@ def preprocess(path, imgsz, lb_val, norm, mean, std):
     r = imgsz / max(h, w)
     nh, nw = int(round(h*r)), int(round(w*r))
     im_res = cv2.resize(im, (nw, nh), interpolation=cv2.INTER_LINEAR)
+    if im_res.ndim == 2:
+        im_res = im_res[:, :, None]
     canvas = np.full((imgsz, imgsz, ch), lb_val, dtype=im.dtype)
     top, left = (imgsz-nh)//2, (imgsz-nw)//2
     canvas[top:top+nh, left:left+nw] = im_res


### PR DESCRIPTION
## Summary
- allow `eval_compare_fp32_int8.py` to normalize inputs when mean and std lists are not length-3

## Testing
- `python scripts/eval_compare_fp32_int8.py --cfg configs/yolov8_pose.yaml --fp32 onnx/yolov8n-pose-fp32.onnx --int8 onnx/yolov8n-pose-fp32.onnx --valdir ultralytics/ultralytics/assets --limit 1` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `pip install --quiet pyyaml onnxruntime numpy opencv-python tqdm` *(fails: Could not find a version that satisfies the requirement pyyaml)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9d5035408323a10ba7401374e173