### PR TITLE
feat: make onnx runtime example easier to run

### DIFF
--- a/ultralytics/examples/YOLOv8-ONNXRuntime/README.md
+++ b/ultralytics/examples/YOLOv8-ONNXRuntime/README.md
@@ -37,7 +37,9 @@ pip install onnxruntime
 After successfully installing the required packages, you can run the YOLOv8 implementation using the following command:
 
 ```bash
-python main.py --model yolov8n.onnx --img image.jpg --conf-thres 0.5 --iou-thres 0.5
+python main.py --model yolov8n.onnx --img image.jpg --conf-thres 0.5 --iou-thres 0.5 --save result.jpg
 ```
 
 Make sure to replace yolov8n.onnx with the path to your YOLOv8 ONNX model file, image.jpg with the path to your input image, and adjust the confidence threshold (conf-thres) and IoU threshold (iou-thres) values as needed.
+
+Use `--save <path>` to write the annotated image to disk and `--show` to display it in a window (requires GUI support).

--- a/ultralytics/examples/YOLOv8-ONNXRuntime/main.py
+++ b/ultralytics/examples/YOLOv8-ONNXRuntime/main.py
@@ -232,6 +232,8 @@ if __name__ == '__main__':
     parser.add_argument('--img', type=str, default=str(ROOT / 'assets/bus.jpg'), help='Path to input image.')
     parser.add_argument('--conf-thres', type=float, default=0.5, help='Confidence threshold')
     parser.add_argument('--iou-thres', type=float, default=0.5, help='NMS IoU threshold')
+    parser.add_argument('--save', type=str, default='', help='Optional path to save the output image')
+    parser.add_argument('--show', action='store_true', help='Display the output image in a window')
     args = parser.parse_args()
 
     # Check the requirements and select the appropriate backend (CPU or GPU)
@@ -243,9 +245,13 @@ if __name__ == '__main__':
     # Perform object detection and obtain the output image
     output_image = detection.main()
 
-    # Display the output image in a window
-    cv2.namedWindow('Output', cv2.WINDOW_NORMAL)
-    cv2.imshow('Output', output_image)
+    # Optionally save the output image
+    if args.save:
+        cv2.imwrite(args.save, output_image)
+        print(f"Saved output image to {args.save}")
 
-    # Wait for a key press to exit
-    cv2.waitKey(0)
+    # Optionally display the output image (requires GUI support)
+    if args.show:
+        cv2.namedWindow('Output', cv2.WINDOW_NORMAL)
+        cv2.imshow('Output', output_image)
+        cv2.waitKey(0)

--- a/ultralytics/examples/YOLOv8-ONNXRuntime/main.py
+++ b/ultralytics/examples/YOLOv8-ONNXRuntime/main.py
@@ -1,9 +1,19 @@
 import argparse
+import sys
+from pathlib import Path
 
 import cv2
 import numpy as np
 import onnxruntime as ort
 import torch
+
+# Allow running the example without installing the package by manually
+# adding the repository root to the Python path. This lets users execute the
+# script directly with ``python examples/...`` without ``export PYTHONPATH``.
+FILE = Path(__file__).resolve()
+REPO_ROOT = FILE.parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.append(str(REPO_ROOT))
 
 from ultralytics.yolo.utils import ROOT, yaml_load
 from ultralytics.yolo.utils.checks import check_requirements, check_yaml
@@ -181,7 +191,10 @@ class Yolov8:
             output_img: The output image with drawn detections.
         """
         # Create an inference session using the ONNX model and specify execution providers
-        session = ort.InferenceSession(self.onnx_model, providers=['CUDAExecutionProvider', 'CPUExecutionProvider'])
+        providers = ['CPUExecutionProvider']
+        if 'CUDAExecutionProvider' in ort.get_available_providers():
+            providers.insert(0, 'CUDAExecutionProvider')
+        session = ort.InferenceSession(self.onnx_model, providers=providers)
 
         # Get the model inputs
         model_inputs = session.get_inputs()


### PR DESCRIPTION
## Summary
- allow ONNXRuntime example to run without PYTHONPATH by appending repo root
- fall back to CPU execution provider when CUDA libraries are unavailable

## Testing
- `python ultralytics/examples/YOLOv8-ONNXRuntime/main.py --model onnx/yolov8n-pose-int8.onnx --img val/pose/1_00_01_00336.jpg` *(fails: ModuleNotFoundError: No module named 'cv2')*
- `pip install opencv-python==4.8.0.74 onnxruntime==1.17.1 numpy==1.24.4 -q` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68aaa85fdf7483238bea52a5ae4c0e55