### PR TITLE
Handle pose model outputs in YOLOv8 ONNXRuntime example

### DIFF
--- a/ultralytics/examples/YOLOv8-ONNXRuntime/main.py
+++ b/ultralytics/examples/YOLOv8-ONNXRuntime/main.py
@@ -137,19 +137,19 @@ class Yolov8:
 
         # Iterate over each row in the outputs array
         for i in range(rows):
-            # Extract the class scores from the current row
-            classes_scores = outputs[i][4:]
+            # Extract the detection score for the single class model
+            score = outputs[i][4]
 
-            # Find the maximum score among the class scores
-            max_score = np.amax(classes_scores)
-
-            # If the maximum score is above the confidence threshold
-            if max_score >= self.confidence_thres:
-                # Get the class ID with the highest score
-                class_id = np.argmax(classes_scores)
+            # If the detection score is above the confidence threshold
+            if score >= self.confidence_thres:
+                # Pose models have a single class (e.g., 'person')
+                class_id = 0
 
                 # Extract the bounding box coordinates from the current row
                 x, y, w, h = outputs[i][0], outputs[i][1], outputs[i][2], outputs[i][3]
+
+                # Optional: parse keypoints for drawing if desired
+                keypoints = outputs[i][5:]
 
                 # Calculate the scaled coordinates of the bounding box
                 left = int((x - w / 2) * x_factor)
@@ -159,7 +159,7 @@ class Yolov8:
 
                 # Add the class ID, score, and box coordinates to the respective lists
                 class_ids.append(class_id)
-                scores.append(max_score)
+                scores.append(score)
                 boxes.append([left, top, width, height])
 
         # Apply non-maximum suppression to filter out overlapping bounding boxes


### PR DESCRIPTION
## Summary
- Simplify postprocess to use single-class score for pose models
- Optionally parse keypoint data from model outputs

## Testing
- `python ultralytics/examples/YOLOv8-ONNXRuntime/main.py --model onnx/yolov8n-pose-fp32.onnx --save out.jpg` *(fails: ModuleNotFoundError: No module named 'cv2')*
- `pip install -q torch torchvision opencv-python onnxruntime numpy pyyaml tqdm` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68aac974872c8323aa524f9f6133a993