### PR TITLE
Add label handling to calibration prep script

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,4 @@ Quantization for YOLOv8 Pose & TrackNet1000
 
 ## TensorRT INT8 for YOLO-Pose (1-channel)
 See [trt_quant/](trt_quant/README.md) for scripts to export and verify INT8 TensorRT engines with grayscale (1-channel) inputs.
+The `prepare_calib.py` helper can optionally copy labels or create blank ones to match images.

--- a/trt_quant/README.md
+++ b/trt_quant/README.md
@@ -11,9 +11,13 @@ pip install -r trt_quant/requirements.txt
 python trt_quant/scripts/prepare_calib.py \
   --src /path/to/your/images \
   --dst trt_quant/calib/images \
+  --src-labels /path/to/your/labels \  # optional
+  --dst-labels trt_quant/calib/labels \
   --num 300 --imgsz 640 --shuffle
 ```
 `calib.yaml` sets `path: trt_quant/calib`, so run these commands from the repository root.
+
+If `--src-labels` is omitted, blank label files are created in `--dst-labels` to avoid warnings.
 
 Example `trt_quant/calib/calib.yaml`:
 

--- a/trt_quant/scripts/prepare_calib.py
+++ b/trt_quant/scripts/prepare_calib.py
@@ -14,12 +14,16 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--src", required=True, help="source folder of images")
     ap.add_argument("--dst", default="trt_quant/calib/images", help="dest folder")
+    ap.add_argument("--src-labels", help="optional source folder of labels")
+    ap.add_argument("--dst-labels", default="trt_quant/calib/labels",
+                    help="dest folder for labels")
     ap.add_argument("--num", type=int, default=300, help="number of images")
     ap.add_argument("--imgsz", type=int, default=640, help="resize to square (0=keep)")
     ap.add_argument("--shuffle", action="store_true", help="shuffle selection")
     args = ap.parse_args()
 
     os.makedirs(args.dst, exist_ok=True)
+    os.makedirs(args.dst_labels, exist_ok=True)
     files = [p for p in glob.glob(os.path.join(args.src, "**"), recursive=True) if is_image(p)]
     if not files:
         raise SystemExit(f"No images found in {args.src}")
@@ -39,6 +43,18 @@ def main():
             g = cv2.resize(g, (args.imgsz, args.imgsz), interpolation=cv2.INTER_AREA)
         out = os.path.join(args.dst, f"calib_{i:04d}.png")
         cv2.imwrite(out, g)
+
+        label_out = os.path.join(args.dst_labels, f"calib_{i:04d}.txt")
+        if args.src_labels:
+            rel = os.path.relpath(p, args.src)
+            label_in = os.path.join(
+                args.src_labels, os.path.splitext(rel)[0] + ".txt")
+            if os.path.isfile(label_in):
+                shutil.copy(label_in, label_out)
+            else:
+                open(label_out, "w").close()
+        else:
+            open(label_out, "w").close()
     print(f"Done. Wrote {len(picked)} grayscale images to: {args.dst}")
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Support optional label copying or blank label creation in `prepare_calib.py`
- Allow specifying source and destination label directories

## Testing
- `python -m py_compile trt_quant/scripts/prepare_calib.py`
- `python trt_quant/scripts/prepare_calib.py --help` *(fails: ModuleNotFoundError: No module named 'cv2')*
- `pip install opencv-python-headless` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68c020b112e883238f3163b3cf081814