### PR TITLE
feat: support pose TRT inference

### DIFF
--- a/trt_quant/scripts/predict_trt.py
+++ b/trt_quant/scripts/predict_trt.py
@@ -15,9 +15,16 @@ def main():
     ap.add_argument("--device", default=0)
     ap.add_argument("--save", action="store_true", help="save rendered outputs")
     ap.add_argument("--conf", type=float, default=0.25)
+    ap.add_argument("--task", default="pose", help="model task type (detect, pose, etc.)")
+    ap.add_argument("--channels", type=int, default=1, help="input channels of the engine")
     args = ap.parse_args()
 
-    model = YOLO(args.engine)  # Ultralytics will dispatch to TensorRT runtime
+    # Explicitly pass task to avoid incorrect automatic guessing
+    model = YOLO(args.engine, task=args.task)
+    # Ensure channel count matches engine expectation when metadata is absent
+    if hasattr(model, "predictor") and hasattr(model.predictor, "overrides"):
+        model.predictor.overrides["channels"] = args.channels
+
     results = model.predict(source=args.source, imgsz=args.imgsz, device=args.device,
                             conf=args.conf, save=args.save, stream=True, verbose=False)
 

--- a/trt_quant/scripts/predict_trt.py
+++ b/trt_quant/scripts/predict_trt.py
@@ -37,10 +37,6 @@ def main():
             model.model.ch = args.channels
         if hasattr(model.model, "kpt_shape"):
             model.model.kpt_shape = tuple(args.kpt_shape)
-    if hasattr(model, "overrides"):
-        # Use recognized key 'ch' to override input channels without passing
-        # unsupported arguments to the Ultralytics runtime
-        model.overrides["ch"] = args.channels
 
     results = model.predict(
         source=args.source,

--- a/trt_quant/scripts/predict_trt.py
+++ b/trt_quant/scripts/predict_trt.py
@@ -30,9 +30,12 @@ def main():
     # Explicitly pass task to avoid incorrect automatic guessing
     model = YOLO(args.engine, task=args.task)
     # Ensure channel count and keypoint shape match engine expectation when metadata is absent
-    if hasattr(model, "predictor") and hasattr(model.predictor, "overrides"):
-        model.predictor.overrides["channels"] = args.channels
-        model.predictor.overrides["kpt_shape"] = tuple(args.kpt_shape)
+    if hasattr(model, "model") and hasattr(model.model, "args"):
+        model.model.args["ch"] = args.channels
+        model.model.args["kpt_shape"] = tuple(args.kpt_shape)
+    if hasattr(model, "overrides"):
+        model.overrides["channels"] = args.channels
+        model.overrides["kpt_shape"] = tuple(args.kpt_shape)
 
     results = model.predict(
         source=args.source,
@@ -42,8 +45,6 @@ def main():
         save=args.save,
         stream=True,
         verbose=False,
-        channels=args.channels,
-        kpt_shape=tuple(args.kpt_shape),
     )
 
     n_imgs = 0

--- a/trt_quant/scripts/predict_trt.py
+++ b/trt_quant/scripts/predict_trt.py
@@ -33,9 +33,14 @@ def main():
     if hasattr(model, "model") and hasattr(model.model, "args"):
         model.model.args["ch"] = args.channels
         model.model.args["kpt_shape"] = tuple(args.kpt_shape)
+        if hasattr(model.model, "ch"):
+            model.model.ch = args.channels
+        if hasattr(model.model, "kpt_shape"):
+            model.model.kpt_shape = tuple(args.kpt_shape)
     if hasattr(model, "overrides"):
-        model.overrides["channels"] = args.channels
-        model.overrides["kpt_shape"] = tuple(args.kpt_shape)
+        # Use recognized key 'ch' to override input channels without passing
+        # unsupported arguments to the Ultralytics runtime
+        model.overrides["ch"] = args.channels
 
     results = model.predict(
         source=args.source,


### PR DESCRIPTION
## Summary
- allow specifying YOLO task in TensorRT prediction script
- set channel count override to match grayscale pose engines

## Testing
- `python trt_quant/scripts/predict_trt.py --help` *(fails: ModuleNotFoundError: No module named 'ultralytics')*

------
https://chatgpt.com/codex/tasks/task_e_68c556495280832395b442d5127e7da9