### PR TITLE
feat: add low-light preprocessing

### DIFF
--- a/trt_quant/README.md
+++ b/trt_quant/README.md
@@ -91,6 +91,25 @@ Replace `test.jpg` with a video file or a directory of images to process
 multiple frames. Add `--show` to display the output in a window while
 running.
 
+### Standalone preprocessing helper
+The low-light routine is also available as a Python helper. Import
+`preprocess_for_trt` to convert a BGR or grayscale image into an NCHW
+tensor while applying optional enhancement:
+
+```python
+import cv2 as cv
+from trt_quant.preprocess import preprocess_for_trt
+
+img = cv.imread("dark_scene.jpg")  # BGR or gray
+tensor = preprocess_for_trt(img,
+                            enable=True,      # set False to skip enhancement
+                            gamma=0.85,
+                            use_clahe=True,
+                            clahe_clip=2.0,
+                            clahe_grid=8)
+# tensor: float32 [1,1,H,W] in range 0~1
+```
+
 ## 6) Compare FP32(.pt) vs INT8(.engine)
 ```bash
 python trt_quant/scripts/compare_pt_vs_trt.py \

--- a/trt_quant/README.md
+++ b/trt_quant/README.md
@@ -76,8 +76,9 @@ the script adjusts automatically; otherwise set `--nc` to match your
 class count.
 
 Optional low-light enhancement is available with `--ll-enhance`.
-Gamma, CLAHE clip limit, and grid size can be tuned via `--ll-gamma`,
-`--ll-clip`, and `--ll-grid` respectively.
+Gamma, CLAHE usage, clip limit, and grid size can be tuned via
+`--ll-gamma`, `--ll-clahe/--no-ll-clahe`, `--ll-clip`, and `--ll-grid`
+respectively.
 
 ```bash
 python trt_quant/scripts/predict_trt.py \

--- a/trt_quant/README.md
+++ b/trt_quant/README.md
@@ -75,6 +75,10 @@ If your engine omits class probabilities (e.g. a single-class model),
 the script adjusts automatically; otherwise set `--nc` to match your
 class count.
 
+Optional low-light enhancement is available with `--ll-enhance`.
+Gamma, CLAHE clip limit, and grid size can be tuned via `--ll-gamma`,
+`--ll-clip`, and `--ll-grid` respectively.
+
 ```bash
 python trt_quant/scripts/predict_trt.py \
   --engine trt_quant/engine/pose_int8.engine \

--- a/trt_quant/preprocess/__init__.py
+++ b/trt_quant/preprocess/__init__.py
@@ -1,0 +1,6 @@
+from .ll_enhance import (
+    add_ll_flags,
+    ensure_gray_u8,
+    ll_enhance_u8,
+    preprocess_for_trt,
+)

--- a/trt_quant/preprocess/ll_enhance.py
+++ b/trt_quant/preprocess/ll_enhance.py
@@ -22,8 +22,12 @@ def add_ll_flags(ap: argparse.ArgumentParser):
                     help="啟用低亮度強化 (Gamma + CLAHE)")
     ap.add_argument("--ll-gamma", type=float, default=0.85,
                     help="gamma < 1 會提亮暗部；=1 不變")
-    ap.add_argument("--ll-clahe", action="store_true", default=True,
-                    help="是否啟用 CLAHE")
+    ap.add_argument(
+        "--ll-clahe",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="是否啟用 CLAHE",
+    )
     ap.add_argument("--ll-clip", type=float, default=2.0,
                     help="CLAHE clipLimit")
     ap.add_argument("--ll-grid", type=int, default=8,

--- a/trt_quant/preprocess/ll_enhance.py
+++ b/trt_quant/preprocess/ll_enhance.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+# -*- coding: utf-8 -*-
+"""
+灰階 1ch 前處理：Gamma + CLAHE（可開關）
+提供給 TensorRT 路徑：回傳 float32 NCHW [1,1,H,W]，值域 0~1
+"""
+import argparse
+from typing import Optional
+try:
+    import cv2 as cv
+except Exception:  # pragma: no cover
+    cv = None  # type: ignore
+try:
+    import numpy as np
+except Exception:  # pragma: no cover
+    np = None  # type: ignore
+
+
+def add_ll_flags(ap: argparse.ArgumentParser):
+    ap.add_argument("--ll-enhance", action="store_true",
+                    help="啟用低亮度強化 (Gamma + CLAHE)")
+    ap.add_argument("--ll-gamma", type=float, default=0.85,
+                    help="gamma < 1 會提亮暗部；=1 不變")
+    ap.add_argument("--ll-clahe", action="store_true", default=True,
+                    help="是否啟用 CLAHE")
+    ap.add_argument("--ll-clip", type=float, default=2.0,
+                    help="CLAHE clipLimit")
+    ap.add_argument("--ll-grid", type=int, default=8,
+                    help="CLAHE tileGridSize 的邊長")
+
+
+def ensure_gray_u8(img: np.ndarray) -> np.ndarray:
+    """
+    將輸入統一為灰階 uint8: (H, W)
+    支援 BGR/Gray、uint8/float32/float64
+    """
+    if img is None:
+        raise ValueError("ensure_gray_u8: input is None")
+    if cv is None:
+        raise ImportError("opencv-python is required for ensure_gray_u8")
+    x = img
+    if x.ndim == 3 and x.shape[2] == 3:
+        x = cv.cvtColor(x, cv.COLOR_BGR2GRAY)
+    if x.dtype in (np.float32, np.float64):
+        x = (x * 255.0).clip(0, 255).astype(np.uint8)
+    elif x.dtype != np.uint8:
+        x = x.astype(np.uint8)
+    return x
+
+
+def ll_enhance_u8(gray_u8: np.ndarray,
+                  gamma: Optional[float] = 0.85,
+                  use_clahe: bool = True,
+                  clahe_clip: float = 2.0,
+                  clahe_grid: int = 8) -> np.ndarray:
+    """
+    回傳增強後的灰階 uint8 (H, W)
+    1) gamma 校正（<1 提亮暗部）
+    2) CLAHE 局部對比增強
+    """
+    if np is None:
+        raise ImportError("numpy is required for ll_enhance_u8")
+    g = ensure_gray_u8(gray_u8).astype(np.float32) / 255.0
+    if gamma is not None:
+        g = np.power(g, float(gamma))
+    g = (g * 255.0).clip(0, 255).astype(np.uint8)
+
+    if use_clahe:
+        if cv is None:
+            raise ImportError("opencv-python is required for CLAHE")
+        clahe = cv.createCLAHE(clipLimit=float(clahe_clip),
+                               tileGridSize=(int(clahe_grid), int(clahe_grid)))
+        g = clahe.apply(g)
+    return g
+
+
+def _to_nchw_float01(gray_u8: np.ndarray, normalize: bool = True) -> np.ndarray:
+    """
+    轉成 float32 NCHW [1,1,H,W]，0~1
+    """
+    if np is None:
+        raise ImportError("numpy is required for _to_nchw_float01")
+    g = ensure_gray_u8(gray_u8).astype(np.float32)
+    if normalize:
+        g /= 255.0
+    return g[None, None, ...]  # [1,1,H,W]
+
+
+def preprocess_for_trt(img: np.ndarray,
+                       enable: bool,
+                       gamma: float,
+                       use_clahe: bool,
+                       clahe_clip: float,
+                       clahe_grid: int) -> np.ndarray:
+    """
+    提供給 predict_trt.py：一行搞定前處理 + 打包成 NCHW tensor
+    """
+    if np is None:
+        raise ImportError("numpy is required for preprocess_for_trt")
+    g = ensure_gray_u8(img)
+    if enable:
+        g = ll_enhance_u8(g, gamma, use_clahe, clahe_clip, clahe_grid)
+    return _to_nchw_float01(g, normalize=True)

--- a/trt_quant/scripts/predict_trt.py
+++ b/trt_quant/scripts/predict_trt.py
@@ -38,7 +38,7 @@ def parse_args() -> argparse.Namespace:
     ap.add_argument("--show", action="store_true", help="display predictions")
     ap.add_argument("--nc", type=int, default=1, help="number of classes")
     ap.add_argument("--nkpt", type=int, default=17, help="number of keypoints")
-    add_ll_flags(ap)
+    add_ll_flags(ap)  # adds --ll-enhance/--ll-gamma/--ll-clahe/--ll-clip/--ll-grid
     return ap.parse_args()
 
 


### PR DESCRIPTION
## Summary
- add grayscale low-light enhancement preprocessing with gamma and CLAHE
- hook preprocessing into predict_trt TensorRT runner via new CLI flags
- document low-light options in README

## Testing
- `python -m py_compile preprocess/ll_enhance.py scripts/predict_trt.py`
- `python scripts/predict_trt.py --help`
- `pip install opencv-python` *(fails: Could not connect to proxy)*
- `pip install numpy` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68c817f75128832388d17fdd1798a33a