### PR TITLE
Add folder-based batch processing for TRT demo and validation scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Python cache
+*.pyc
+__pycache__/
+
+# Outputs and artifacts
+artifacts/
+runs/
+out/
+trt_quant/
+ultralytics/
+val/

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This stage validates the TensorRT pipeline and prints the required summary to co
 python demo_infer_trt.py \
   --engine path/to/model.engine \
   --img path/to/img1.jpg path/to/img2.jpg path/to/img3.jpg \
+  --out-dir outputs \
   --imgsz 640 640 \
   --conf 0.25 \
   --iou 0.7
@@ -31,6 +32,7 @@ To process an entire folder in batches of 3 images:
 python demo_infer_trt.py \
   --engine path/to/model.engine \
   --img-dir path/to/images \
+  --out-dir outputs \
   --imgsz 640 640 \
   --conf 0.25 \
   --iou 0.7

--- a/README.md
+++ b/README.md
@@ -1,2 +1,108 @@
 # YOLOv8-Edge-Quantization
-Quantization for YOLOv8 Pose &amp; TrackNet1000
+
+Quantization for YOLOv8 Pose & TrackNet1000.
+
+## TensorRT YOLOv8 Pose 3-in/3-out Manual
+
+This repo includes a TensorRT inference pipeline that accepts **three input frames** and returns a list of **three results** in the same format as the PyTorch version.
+
+### Stage 1: Prepare assets
+
+1. **TensorRT engine**: export a YOLOv8 Pose engine that supports explicit batch and dynamic shape with an optimization profile where `max` batch is at least 3.
+2. **PyTorch weights** (optional, for validation): `*.pt` file for the same model.
+3. **Inputs**: three images or three frames extracted from a video.
+
+### Stage 2: Run demo inference (TensorRT only)
+
+This stage validates the TensorRT pipeline and prints the required summary to confirm the `3-in/3-out` behavior.
+
+```bash
+python demo_infer_trt.py \
+  --engine path/to/model.engine \
+  --img path/to/img1.jpg path/to/img2.jpg path/to/img3.jpg \
+  --imgsz 640 640 \
+  --conf 0.25 \
+  --iou 0.7
+```
+
+To process an entire folder in batches of 3 images:
+
+```bash
+python demo_infer_trt.py \
+  --engine path/to/model.engine \
+  --img-dir path/to/images \
+  --imgsz 640 640 \
+  --conf 0.25 \
+  --iou 0.7
+```
+
+Expected output includes:
+
+- `len(results) = 3`
+- per-frame summary with `orig_shape`, `boxes`, and keypoint counts
+- `keypoints.xy shape: (N, 17, 2)` (and `keypoints.conf shape` if available)
+
+### Stage 3: Validate vs PyTorch (optional but recommended)
+
+This stage compares TensorRT output against PyTorch on the same 3-frame input to catch preprocess or decode mismatches quickly.
+
+```bash
+python validate_vs_torch.py \
+  --engine path/to/model.engine \
+  --weights path/to/model.pt \
+  --img path/to/img1.jpg path/to/img2.jpg path/to/img3.jpg \
+  --imgsz 640 640 \
+  --conf 0.25 \
+  --iou 0.7
+```
+
+To validate a folder in batches of 3 images:
+
+```bash
+python validate_vs_torch.py \
+  --engine path/to/model.engine \
+  --weights path/to/model.pt \
+  --img-dir path/to/images \
+  --imgsz 640 640 \
+  --conf 0.25 \
+  --iou 0.7
+```
+
+The script prints:
+
+- number of boxes per frame (PyTorch vs TRT)
+- mean keypoint pixel error for matched detections
+- mean confidence for matched boxes
+
+### Stage 4: Use the API in your own code
+
+```python
+from api_infer import PoseTRTInfer
+
+infer = PoseTRTInfer(
+    engine_path="path/to/model.engine",
+    conf=0.25,
+    iou=0.7,
+    imgsz=(640, 640),
+)
+
+results = infer.infer_3in3out([frame1, frame2, frame3])
+print(len(results))  # 3
+```
+
+### Stage 5: Debug helpers
+
+- Inspect engine bindings:
+
+```python
+from trt_runner import TrtRunner
+
+runner = TrtRunner("path/to/model.engine")
+runner.dump_bindings()
+```
+
+- Enable verbose shape prints during inference:
+
+```python
+outputs = runner.infer(batch, verbose=True)
+```

--- a/README.md
+++ b/README.md
@@ -19,11 +19,12 @@ This stage validates the TensorRT pipeline and prints the required summary to co
 ```bash
 python demo_infer_trt.py \
   --engine path/to/model.engine \
-  --img path/to/img1.jpg path/to/img2.jpg path/to/img3.jpg \
+  --source path/to/img1.jpg \
   --out-dir outputs \
-  --imgsz 640 640 \
+  --imgsz 640 \
   --conf 0.25 \
-  --iou 0.7
+  --iou 0.7 \
+  --save
 ```
 
 To process an entire folder in batches of 3 images:
@@ -33,9 +34,10 @@ python demo_infer_trt.py \
   --engine path/to/model.engine \
   --img-dir path/to/images \
   --out-dir outputs \
-  --imgsz 640 640 \
+  --imgsz 640 \
   --conf 0.25 \
-  --iou 0.7
+  --iou 0.7 \
+  --save
 ```
 
 Expected output includes:

--- a/api_infer.py
+++ b/api_infer.py
@@ -1,0 +1,28 @@
+from typing import List, Sequence, Tuple
+
+import numpy as np
+
+from preprocess import preprocess_3
+from postprocess import Result, postprocess_batch
+from trt_runner import TrtRunner
+
+
+class PoseTRTInfer:
+    def __init__(
+        self,
+        engine_path: str,
+        conf: float = 0.25,
+        iou: float = 0.7,
+        imgsz: Tuple[int, int] = (640, 640),
+        profile_index: int = 0,
+    ) -> None:
+        self.conf = conf
+        self.iou = iou
+        self.imgsz = imgsz
+        self.runner = TrtRunner(engine_path, profile_index=profile_index)
+
+    def infer_3in3out(self, frames3: Sequence[np.ndarray]) -> List[Result]:
+        x, metas = preprocess_3(frames3, self.imgsz)
+        outputs = self.runner.infer(x, verbose=True)
+        results = postprocess_batch(outputs, metas, self.conf, self.iou, verbose=True)
+        return results

--- a/api_infer.py
+++ b/api_infer.py
@@ -15,14 +15,20 @@ class PoseTRTInfer:
         iou: float = 0.7,
         imgsz: Tuple[int, int] = (640, 640),
         profile_index: int = 0,
+        to_gray: bool | None = None,
     ) -> None:
         self.conf = conf
         self.iou = iou
         self.imgsz = imgsz
         self.runner = TrtRunner(engine_path, profile_index=profile_index)
+        if to_gray is None:
+            channel_count = self.runner.get_input_channel_count()
+            self.to_gray = channel_count == 1
+        else:
+            self.to_gray = to_gray
 
     def infer_3in3out(self, frames3: Sequence[np.ndarray]) -> List[Result]:
-        x, metas = preprocess_3(frames3, self.imgsz)
+        x, metas = preprocess_3(frames3, self.imgsz, to_gray=self.to_gray)
         outputs = self.runner.infer(x, verbose=True)
         results = postprocess_batch(outputs, metas, self.conf, self.iou, verbose=True)
         return results

--- a/demo_infer_trt.py
+++ b/demo_infer_trt.py
@@ -242,6 +242,26 @@ def infer(
     keep = nms(boxes, scores, iou)
     boxes, scores, kpts = boxes[keep], scores[keep], kpts[keep]
 
+    skeleton = [
+        (0, 1),
+        (0, 2),
+        (1, 3),
+        (2, 4),
+        (0, 5),
+        (0, 6),
+        (5, 7),
+        (7, 9),
+        (6, 8),
+        (8, 10),
+        (5, 6),
+        (5, 11),
+        (6, 12),
+        (11, 12),
+        (11, 13),
+        (13, 15),
+        (12, 14),
+        (14, 16),
+    ]
     for box, score, kp in zip(boxes, scores, kpts):
         x1, y1, x2, y2 = map(int, box)
         cv2.rectangle(im0, (x1, y1), (x2, y2), (255, 0, 0), 1)
@@ -259,6 +279,11 @@ def infer(
         for x, y, c in kp:
             if c > 0:
                 cv2.circle(im0, (int(x), int(y)), 2, (54, 172, 245), -1)
+        for a, b in skeleton:
+            if kp[a, 2] > 0 and kp[b, 2] > 0:
+                ax, ay = kp[a, 0], kp[a, 1]
+                bx, by = kp[b, 0], kp[b, 1]
+                cv2.line(im0, (int(ax), int(ay)), (int(bx), int(by)), (0, 255, 0), 1)
     return im0, boxes, kpts
 
 

--- a/demo_infer_trt.py
+++ b/demo_infer_trt.py
@@ -1,0 +1,105 @@
+import argparse
+from pathlib import Path
+from typing import List, Sequence
+
+import cv2
+
+from api_infer import PoseTRTInfer
+
+
+def load_images(paths: Sequence[str]):
+    frames = []
+    for path in paths:
+        frame = cv2.imread(path)
+        if frame is None:
+            raise FileNotFoundError(f"Failed to read image: {path}")
+        frames.append(frame)
+    return frames
+
+
+def load_images_from_dir(img_dir: str) -> List[str]:
+    dir_path = Path(img_dir)
+    if not dir_path.exists():
+        raise FileNotFoundError(f"Image directory not found: {img_dir}")
+    image_paths = sorted(
+        str(p)
+        for p in dir_path.iterdir()
+        if p.suffix.lower() in {".jpg", ".jpeg", ".png", ".bmp"}
+    )
+    if not image_paths:
+        raise FileNotFoundError(f"No images found in directory: {img_dir}")
+    return image_paths
+
+
+def chunked(items: List[str], batch_size: int) -> List[List[str]]:
+    return [items[i : i + batch_size] for i in range(0, len(items), batch_size)]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--engine", required=True, help="Path to TensorRT engine")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--img", nargs=3, help="Three image paths")
+    group.add_argument("--img-dir", help="Directory containing images to process in batches of 3")
+    parser.add_argument("--imgsz", nargs=2, type=int, default=[640, 640])
+    parser.add_argument("--conf", type=float, default=0.25)
+    parser.add_argument("--iou", type=float, default=0.7)
+    args = parser.parse_args()
+
+    infer = PoseTRTInfer(args.engine, conf=args.conf, iou=args.iou, imgsz=tuple(args.imgsz))
+    if args.img_dir:
+        image_paths = load_images_from_dir(args.img_dir)
+        batches = chunked(image_paths, 3)
+        if len(batches[-1]) < 3:
+            print(
+                f"[demo] warning: dropping last {len(batches[-1])} image(s) to keep batch=3"
+            )
+            batches = batches[:-1]
+        for batch_idx, batch_paths in enumerate(batches):
+            frames3 = load_images(batch_paths)
+            results = infer.infer_3in3out(frames3)
+            print(f"[batch {batch_idx}] len(results) = {len(results)}")
+            for idx, res in enumerate(results):
+                kpts = res.keypoints
+                kpt_instances = 0
+                kpt_xy_shape = None
+                kpt_conf_shape = None
+                if kpts is not None:
+                    kpt_instances = kpts.xy.shape[0]
+                    kpt_xy_shape = kpts.xy.shape
+                    if kpts.conf is not None:
+                        kpt_conf_shape = kpts.conf.shape
+                print(
+                    f"[{idx}] orig_shape={res.orig_shape}, boxes={res.boxes.shape}, "
+                    f"kpt_instances={kpt_instances}"
+                )
+                if kpt_xy_shape is not None:
+                    print(f"keypoints.xy shape: {kpt_xy_shape}")
+                if kpt_conf_shape is not None:
+                    print(f"keypoints.conf shape: {kpt_conf_shape}")
+    else:
+        frames3 = load_images(args.img)
+        results = infer.infer_3in3out(frames3)
+        print(f"len(results) = {len(results)}")
+        for idx, res in enumerate(results):
+            kpts = res.keypoints
+            kpt_instances = 0
+            kpt_xy_shape = None
+            kpt_conf_shape = None
+            if kpts is not None:
+                kpt_instances = kpts.xy.shape[0]
+                kpt_xy_shape = kpts.xy.shape
+                if kpts.conf is not None:
+                    kpt_conf_shape = kpts.conf.shape
+            print(
+                f"[{idx}] orig_shape={res.orig_shape}, boxes={res.boxes.shape}, "
+                f"kpt_instances={kpt_instances}"
+            )
+            if kpt_xy_shape is not None:
+                print(f"keypoints.xy shape: {kpt_xy_shape}")
+            if kpt_conf_shape is not None:
+                print(f"keypoints.conf shape: {kpt_conf_shape}")
+
+
+if __name__ == "__main__":
+    main()

--- a/demo_infer_trt.py
+++ b/demo_infer_trt.py
@@ -1,8 +1,9 @@
 import argparse
 from pathlib import Path
-from typing import List, Sequence
+from typing import List, Sequence, Tuple
 
 import cv2
+import numpy as np
 
 from api_infer import PoseTRTInfer
 
@@ -35,18 +36,89 @@ def chunked(items: List[str], batch_size: int) -> List[List[str]]:
     return [items[i : i + batch_size] for i in range(0, len(items), batch_size)]
 
 
+def _draw_pose(
+    image: np.ndarray,
+    boxes: np.ndarray,
+    keypoints: np.ndarray,
+    kpt_conf: np.ndarray | None,
+    conf_thr: float,
+) -> np.ndarray:
+    skeleton = [
+        (0, 1),
+        (0, 2),
+        (1, 3),
+        (2, 4),
+        (0, 5),
+        (0, 6),
+        (5, 7),
+        (7, 9),
+        (6, 8),
+        (8, 10),
+        (5, 6),
+        (5, 11),
+        (6, 12),
+        (11, 12),
+        (11, 13),
+        (13, 15),
+        (12, 14),
+        (14, 16),
+    ]
+    output = image.copy()
+    for box in boxes.astype(int):
+        cv2.rectangle(output, (box[0], box[1]), (box[2], box[3]), (0, 255, 0), 2)
+    if keypoints.size == 0:
+        return output
+    for person_idx, person_kpts in enumerate(keypoints):
+        for kpt_idx, (x, y) in enumerate(person_kpts):
+            if kpt_conf is not None and kpt_conf[person_idx, kpt_idx] < conf_thr:
+                continue
+            cv2.circle(output, (int(x), int(y)), 3, (0, 255, 255), -1)
+        for a, b in skeleton:
+            if kpt_conf is not None:
+                if kpt_conf[person_idx, a] < conf_thr or kpt_conf[person_idx, b] < conf_thr:
+                    continue
+            x1, y1 = person_kpts[a]
+            x2, y2 = person_kpts[b]
+            cv2.line(output, (int(x1), int(y1)), (int(x2), int(y2)), (255, 0, 0), 2)
+    return output
+
+
+def _save_outputs(
+    out_dir: Path,
+    batch_paths: List[str],
+    frames: Sequence[np.ndarray],
+    results,
+    conf_thr: float,
+    batch_idx: int,
+) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for idx, (path, frame, res) in enumerate(zip(batch_paths, frames, results)):
+        stem = Path(path).stem
+        if res.keypoints is not None:
+            kpts = res.keypoints.xy
+            kpt_conf = res.keypoints.conf
+        else:
+            kpts = np.zeros((0, 17, 2), dtype=np.float32)
+            kpt_conf = None
+        drawn = _draw_pose(frame, res.boxes, kpts, kpt_conf, conf_thr)
+        out_path = out_dir / f"batch{batch_idx:03d}_{idx:02d}_{stem}.jpg"
+        cv2.imwrite(str(out_path), drawn)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--engine", required=True, help="Path to TensorRT engine")
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--img", nargs=3, help="Three image paths")
     group.add_argument("--img-dir", help="Directory containing images to process in batches of 3")
+    parser.add_argument("--out-dir", default="trt_outputs", help="Directory to save drawn results")
     parser.add_argument("--imgsz", nargs=2, type=int, default=[640, 640])
     parser.add_argument("--conf", type=float, default=0.25)
     parser.add_argument("--iou", type=float, default=0.7)
     args = parser.parse_args()
 
     infer = PoseTRTInfer(args.engine, conf=args.conf, iou=args.iou, imgsz=tuple(args.imgsz))
+    out_dir = Path(args.out_dir)
     if args.img_dir:
         image_paths = load_images_from_dir(args.img_dir)
         batches = chunked(image_paths, 3)
@@ -59,6 +131,7 @@ def main() -> None:
             frames3 = load_images(batch_paths)
             results = infer.infer_3in3out(frames3)
             print(f"[batch {batch_idx}] len(results) = {len(results)}")
+            _save_outputs(out_dir, batch_paths, frames3, results, args.conf, batch_idx)
             for idx, res in enumerate(results):
                 kpts = res.keypoints
                 kpt_instances = 0
@@ -81,6 +154,7 @@ def main() -> None:
         frames3 = load_images(args.img)
         results = infer.infer_3in3out(frames3)
         print(f"len(results) = {len(results)}")
+        _save_outputs(out_dir, list(args.img), frames3, results, args.conf, 0)
         for idx, res in enumerate(results):
             kpts = res.keypoints
             kpt_instances = 0

--- a/postprocess.py
+++ b/postprocess.py
@@ -1,0 +1,162 @@
+import dataclasses
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+
+
+@dataclasses.dataclass
+class Keypoints:
+    xy: np.ndarray
+    conf: Optional[np.ndarray] = None
+
+
+@dataclasses.dataclass
+class Result:
+    boxes: np.ndarray
+    scores: np.ndarray
+    keypoints: Optional[Keypoints]
+    orig_shape: Tuple[int, int]
+
+
+def _nms(boxes: np.ndarray, scores: np.ndarray, iou_thresh: float) -> List[int]:
+    if boxes.size == 0:
+        return []
+    x1 = boxes[:, 0]
+    y1 = boxes[:, 1]
+    x2 = boxes[:, 2]
+    y2 = boxes[:, 3]
+    areas = (x2 - x1 + 1) * (y2 - y1 + 1)
+    order = scores.argsort()[::-1]
+    keep: List[int] = []
+    while order.size > 0:
+        i = int(order[0])
+        keep.append(i)
+        xx1 = np.maximum(x1[i], x1[order[1:]])
+        yy1 = np.maximum(y1[i], y1[order[1:]])
+        xx2 = np.minimum(x2[i], x2[order[1:]])
+        yy2 = np.minimum(y2[i], y2[order[1:]])
+        w = np.maximum(0.0, xx2 - xx1 + 1)
+        h = np.maximum(0.0, yy2 - yy1 + 1)
+        inter = w * h
+        ovr = inter / (areas[i] + areas[order[1:]] - inter)
+        inds = np.where(ovr <= iou_thresh)[0]
+        order = order[inds + 1]
+    return keep
+
+
+def _xywh_to_xyxy(xywh: np.ndarray) -> np.ndarray:
+    x, y, w, h = xywh.T
+    x1 = x - w / 2
+    y1 = y - h / 2
+    x2 = x + w / 2
+    y2 = y + h / 2
+    return np.stack([x1, y1, x2, y2], axis=1)
+
+
+def _select_prediction_output(outputs: Dict[str, np.ndarray]) -> np.ndarray:
+    if len(outputs) == 1:
+        return next(iter(outputs.values()))
+    best_name = None
+    best_size = -1
+    for name, arr in outputs.items():
+        size = arr.size
+        if size > best_size:
+            best_size = size
+            best_name = name
+    if best_name is None:
+        raise ValueError("No outputs available for postprocess")
+    return outputs[best_name]
+
+
+def _scale_boxes(
+    boxes: np.ndarray, meta: Dict[str, Any]
+) -> np.ndarray:
+    pad_w, pad_h = meta.get("pad", (0, 0))
+    ratio = meta.get("ratio", 1.0)
+    offset_x = meta.get("offset_x", 0)
+    offset_y = meta.get("offset_y", 0)
+    boxes[:, [0, 2]] -= pad_w
+    boxes[:, [1, 3]] -= pad_h
+    boxes[:, :4] /= ratio
+    boxes[:, [0, 2]] += offset_x
+    boxes[:, [1, 3]] += offset_y
+    return boxes
+
+
+def _scale_keypoints(
+    kpts: np.ndarray, meta: Dict[str, Any]
+) -> np.ndarray:
+    pad_w, pad_h = meta.get("pad", (0, 0))
+    ratio = meta.get("ratio", 1.0)
+    offset_x = meta.get("offset_x", 0)
+    offset_y = meta.get("offset_y", 0)
+    kpts[..., 0] = (kpts[..., 0] - pad_w) / ratio + offset_x
+    kpts[..., 1] = (kpts[..., 1] - pad_h) / ratio + offset_y
+    return kpts
+
+
+def postprocess_batch(
+    outputs: Dict[str, np.ndarray],
+    metas: List[Dict[str, Any]],
+    conf: float,
+    iou: float,
+    num_kpts: int = 17,
+    verbose: bool = True,
+) -> List[Result]:
+    pred = _select_prediction_output(outputs)
+    if verbose:
+        print(f"[postprocess] raw pred shape: {pred.shape}")
+    if pred.ndim == 3 and pred.shape[1] < pred.shape[2]:
+        if verbose:
+            print("[postprocess] transpose pred from (B,no,n) to (B,n,no)")
+        pred = pred.transpose(0, 2, 1)
+    if pred.ndim != 3:
+        raise ValueError("Prediction output must be 3D (B,N,NO)")
+    batch_size = pred.shape[0]
+    results: List[Result] = []
+    for b in range(batch_size):
+        pred_b = pred[b]
+        if verbose:
+            print(f"[postprocess] batch {b} pred shape: {pred_b.shape}")
+        if pred_b.shape[1] < 5:
+            raise ValueError("Prediction output must have at least 5 columns")
+        scores = pred_b[:, 4]
+        keep_mask = scores >= conf
+        pred_b = pred_b[keep_mask]
+        scores = scores[keep_mask]
+        boxes = _xywh_to_xyxy(pred_b[:, :4]) if pred_b.size else np.zeros((0, 4))
+        kpts = None
+        kpt_conf = None
+        extra = pred_b[:, 5:]
+        if extra.size and (extra.shape[1] % 3 == 0):
+            kpt_dim = 3
+            kpts = extra.reshape(-1, extra.shape[1] // kpt_dim, kpt_dim)
+            kpt_conf = kpts[..., 2]
+            kpts = kpts[..., :2]
+        elif extra.size and (extra.shape[1] % 2 == 0):
+            kpt_dim = 2
+            kpts = extra.reshape(-1, extra.shape[1] // kpt_dim, kpt_dim)
+        if boxes.size:
+            keep_indices = _nms(boxes, scores, iou)
+            boxes = boxes[keep_indices]
+            scores = scores[keep_indices]
+            if kpts is not None:
+                kpts = kpts[keep_indices]
+                if kpt_conf is not None:
+                    kpt_conf = kpt_conf[keep_indices]
+        if boxes.size:
+            boxes = _scale_boxes(boxes, metas[b])
+        if kpts is not None and kpts.size:
+            kpts = _scale_keypoints(kpts, metas[b])
+        keypoints = None
+        if kpts is not None:
+            keypoints = Keypoints(xy=kpts, conf=kpt_conf)
+        results.append(
+            Result(
+                boxes=boxes,
+                scores=scores,
+                keypoints=keypoints,
+                orig_shape=metas[b]["orig_shape"],
+            )
+        )
+    return results

--- a/preprocess.py
+++ b/preprocess.py
@@ -1,0 +1,77 @@
+from typing import Any, Dict, List, Sequence, Tuple
+
+import cv2
+import numpy as np
+
+
+def _letterbox(
+    image: np.ndarray,
+    new_shape: Tuple[int, int],
+    color: Tuple[int, int, int] = (114, 114, 114),
+) -> Tuple[np.ndarray, float, Tuple[int, int]]:
+    height, width = image.shape[:2]
+    new_h, new_w = new_shape
+    ratio = min(new_h / height, new_w / width)
+    resized_w = int(round(width * ratio))
+    resized_h = int(round(height * ratio))
+    resized = cv2.resize(image, (resized_w, resized_h), interpolation=cv2.INTER_LINEAR)
+    pad_w = new_w - resized_w
+    pad_h = new_h - resized_h
+    pad_left = pad_w // 2
+    pad_right = pad_w - pad_left
+    pad_top = pad_h // 2
+    pad_bottom = pad_h - pad_top
+    padded = cv2.copyMakeBorder(
+        resized, pad_top, pad_bottom, pad_left, pad_right, cv2.BORDER_CONSTANT, value=color
+    )
+    return padded, ratio, (pad_left, pad_top)
+
+
+def preprocess_3(
+    frames3: Sequence[np.ndarray],
+    imgsz: Tuple[int, int],
+    to_gray: bool = False,
+    letterbox: bool = True,
+    mean: Tuple[float, float, float] = (0.0, 0.0, 0.0),
+    std: Tuple[float, float, float] = (1.0, 1.0, 1.0),
+) -> Tuple[np.ndarray, List[Dict[str, Any]]]:
+    if len(frames3) != 3:
+        raise ValueError("frames3 must contain exactly 3 frames")
+    metas: List[Dict[str, Any]] = []
+    processed: List[np.ndarray] = []
+    for frame in frames3:
+        orig_shape = frame.shape[:2]
+        if to_gray:
+            frame = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+            frame = frame[:, :, None]
+        else:
+            frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        if letterbox:
+            resized, ratio, pad = _letterbox(frame, imgsz)
+            input_shape = resized.shape[:2]
+        else:
+            resized = cv2.resize(frame, imgsz[::-1], interpolation=cv2.INTER_LINEAR)
+            ratio = min(imgsz[0] / orig_shape[0], imgsz[1] / orig_shape[1])
+            pad = (0, 0)
+            input_shape = resized.shape[:2]
+        resized = resized.astype(np.float32) / 255.0
+        if resized.ndim == 2:
+            resized = resized[:, :, None]
+        if resized.shape[2] == 3:
+            resized = (resized - np.array(mean, dtype=np.float32)) / np.array(std, dtype=np.float32)
+        else:
+            resized = (resized - mean[0]) / std[0]
+        resized = resized.transpose(2, 0, 1)
+        processed.append(resized)
+        metas.append(
+            {
+                "orig_shape": orig_shape,
+                "input_shape": input_shape,
+                "ratio": ratio,
+                "pad": pad,
+                "offset_x": 0,
+                "offset_y": 0,
+            }
+        )
+    x = np.stack(processed, axis=0).astype(np.float32)
+    return x, metas

--- a/preprocess.py
+++ b/preprocess.py
@@ -74,4 +74,5 @@ def preprocess_3(
             }
         )
     x = np.stack(processed, axis=0).astype(np.float32)
+    x = np.ascontiguousarray(x)
     return x, metas

--- a/trt_runner.py
+++ b/trt_runner.py
@@ -79,6 +79,16 @@ class TrtRunner:
             return self.engine.num_bindings
         return self.engine.num_io_tensors
 
+    def get_input_channel_count(self) -> int | None:
+        input_binding = next(b for b in self.bindings if b.is_input)
+        if hasattr(self.engine, "get_binding_shape"):
+            shape = tuple(self.engine.get_binding_shape(input_binding.index))
+        else:
+            shape = tuple(self.engine.get_tensor_shape(input_binding.name))
+        if len(shape) >= 2:
+            return shape[1]
+        return None
+
     def dump_bindings(self) -> None:
         print("[TrtRunner] Bindings (engine shapes):")
         for binding in self.bindings:

--- a/trt_runner.py
+++ b/trt_runner.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Tuple
 
 import numpy as np
 import tensorrt as trt
+import pycuda.autoinit
 import pycuda.driver as cuda
 
 

--- a/trt_runner.py
+++ b/trt_runner.py
@@ -149,7 +149,12 @@ class TrtRunner:
                             f"[TrtRunner] output {binding.name}: "
                             "transpose may be required based on shape"
                         )
-        self.context.execute_async_v2(bindings=bindings_ptrs, stream_handle=self.stream.handle)
+        if hasattr(self.context, "execute_async_v3"):
+            for binding in self.bindings:
+                self.context.set_tensor_address(binding.name, int(self._device_buffers[binding.index]))
+            self.context.execute_async_v3(stream_handle=self.stream.handle)
+        else:
+            self.context.execute_async_v2(bindings=bindings_ptrs, stream_handle=self.stream.handle)
         for binding in self.bindings:
             if binding.is_input:
                 continue

--- a/validate_vs_torch.py
+++ b/validate_vs_torch.py
@@ -1,0 +1,165 @@
+import argparse
+from pathlib import Path
+from typing import List, Sequence
+
+import cv2
+import numpy as np
+from ultralytics import YOLO
+
+from api_infer import PoseTRTInfer
+
+
+def load_images(paths: Sequence[str]):
+    frames = []
+    for path in paths:
+        frame = cv2.imread(path)
+        if frame is None:
+            raise FileNotFoundError(f"Failed to read image: {path}")
+        frames.append(frame)
+    return frames
+
+
+def load_images_from_dir(img_dir: str) -> List[str]:
+    dir_path = Path(img_dir)
+    if not dir_path.exists():
+        raise FileNotFoundError(f"Image directory not found: {img_dir}")
+    image_paths = sorted(
+        str(p)
+        for p in dir_path.iterdir()
+        if p.suffix.lower() in {".jpg", ".jpeg", ".png", ".bmp"}
+    )
+    if not image_paths:
+        raise FileNotFoundError(f"No images found in directory: {img_dir}")
+    return image_paths
+
+
+def chunked(items: List[str], batch_size: int) -> List[List[str]]:
+    return [items[i : i + batch_size] for i in range(0, len(items), batch_size)]
+
+
+def _pairwise_iou(boxes1: np.ndarray, boxes2: np.ndarray) -> np.ndarray:
+    if boxes1.size == 0 or boxes2.size == 0:
+        return np.zeros((boxes1.shape[0], boxes2.shape[0]))
+    x11, y11, x12, y12 = boxes1[:, 0], boxes1[:, 1], boxes1[:, 2], boxes1[:, 3]
+    x21, y21, x22, y22 = boxes2[:, 0], boxes2[:, 1], boxes2[:, 2], boxes2[:, 3]
+    inter_x1 = np.maximum(x11[:, None], x21[None])
+    inter_y1 = np.maximum(y11[:, None], y21[None])
+    inter_x2 = np.minimum(x12[:, None], x22[None])
+    inter_y2 = np.minimum(y12[:, None], y22[None])
+    inter_w = np.maximum(0.0, inter_x2 - inter_x1 + 1)
+    inter_h = np.maximum(0.0, inter_y2 - inter_y1 + 1)
+    inter = inter_w * inter_h
+    area1 = (x12 - x11 + 1) * (y12 - y11 + 1)
+    area2 = (x22 - x21 + 1) * (y22 - y21 + 1)
+    union = area1[:, None] + area2[None] - inter
+    return inter / np.maximum(union, 1e-6)
+
+
+def _match_by_iou(boxes1: np.ndarray, boxes2: np.ndarray, iou_thresh: float = 0.5):
+    ious = _pairwise_iou(boxes1, boxes2)
+    matches = []
+    for i in range(ious.shape[0]):
+        j = int(np.argmax(ious[i])) if ious.shape[1] else -1
+        if j >= 0 and ious[i, j] >= iou_thresh:
+            matches.append((i, j))
+    return matches
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--engine", required=True, help="Path to TensorRT engine")
+    parser.add_argument("--weights", required=True, help="Path to PyTorch weights")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--img", nargs=3, help="Three image paths")
+    group.add_argument("--img-dir", help="Directory containing images to process in batches of 3")
+    parser.add_argument("--imgsz", nargs=2, type=int, default=[640, 640])
+    parser.add_argument("--conf", type=float, default=0.25)
+    parser.add_argument("--iou", type=float, default=0.7)
+    args = parser.parse_args()
+
+    imgsz = tuple(args.imgsz)
+
+    torch_model = YOLO(args.weights)
+    trt_infer = PoseTRTInfer(args.engine, conf=args.conf, iou=args.iou, imgsz=imgsz)
+    if args.img_dir:
+        image_paths = load_images_from_dir(args.img_dir)
+        batches = chunked(image_paths, 3)
+        if len(batches[-1]) < 3:
+            print(
+                f"[validate] warning: dropping last {len(batches[-1])} image(s) to keep batch=3"
+            )
+            batches = batches[:-1]
+        for batch_idx, batch_paths in enumerate(batches):
+            frames3 = load_images(batch_paths)
+            torch_results = torch_model.predict(
+                frames3, imgsz=imgsz, conf=args.conf, iou=args.iou
+            )
+            trt_results = trt_infer.infer_3in3out(frames3)
+            for idx, (torch_res, trt_res) in enumerate(zip(torch_results, trt_results)):
+                torch_boxes = (
+                    torch_res.boxes.xyxy.cpu().numpy() if torch_res.boxes else np.zeros((0, 4))
+                )
+                trt_boxes = trt_res.boxes
+                print(
+                    f"[batch {batch_idx} frame {idx}] torch boxes: {torch_boxes.shape[0]}, "
+                    f"trt boxes: {trt_boxes.shape[0]}"
+                )
+                matches = _match_by_iou(torch_boxes, trt_boxes)
+                if not matches:
+                    print("  no matches for keypoints comparison")
+                    continue
+                torch_kpts = torch_res.keypoints.xy.cpu().numpy() if torch_res.keypoints else None
+                trt_kpts = trt_res.keypoints.xy if trt_res.keypoints else None
+                if torch_kpts is None or trt_kpts is None:
+                    print("  missing keypoints in one of the results")
+                    continue
+                errors = []
+                for i, j in matches:
+                    t_kpt = torch_kpts[i]
+                    r_kpt = trt_kpts[j]
+                    errors.append(np.linalg.norm(t_kpt - r_kpt, axis=1).mean())
+                if errors:
+                    print(f"  mean keypoint pixel error: {np.mean(errors):.4f}")
+                torch_conf = (
+                    torch_res.boxes.conf.cpu().numpy() if torch_res.boxes else np.array([])
+                )
+                trt_conf = trt_res.scores
+                if torch_conf.size and trt_conf.size:
+                    print(
+                        f"  conf mean (torch/trt): {torch_conf.mean():.4f}/"
+                        f"{trt_conf.mean():.4f}"
+                    )
+    else:
+        frames3 = load_images(args.img)
+        torch_results = torch_model.predict(frames3, imgsz=imgsz, conf=args.conf, iou=args.iou)
+        trt_results = trt_infer.infer_3in3out(frames3)
+        for idx, (torch_res, trt_res) in enumerate(zip(torch_results, trt_results)):
+            torch_boxes = torch_res.boxes.xyxy.cpu().numpy() if torch_res.boxes else np.zeros((0, 4))
+            trt_boxes = trt_res.boxes
+            print(f"[frame {idx}] torch boxes: {torch_boxes.shape[0]}, trt boxes: {trt_boxes.shape[0]}")
+            matches = _match_by_iou(torch_boxes, trt_boxes)
+            if not matches:
+                print("  no matches for keypoints comparison")
+                continue
+            torch_kpts = torch_res.keypoints.xy.cpu().numpy() if torch_res.keypoints else None
+            trt_kpts = trt_res.keypoints.xy if trt_res.keypoints else None
+            if torch_kpts is None or trt_kpts is None:
+                print("  missing keypoints in one of the results")
+                continue
+            errors = []
+            for i, j in matches:
+                t_kpt = torch_kpts[i]
+                r_kpt = trt_kpts[j]
+                errors.append(np.linalg.norm(t_kpt - r_kpt, axis=1).mean())
+            if errors:
+                print(f"  mean keypoint pixel error: {np.mean(errors):.4f}")
+            torch_conf = torch_res.boxes.conf.cpu().numpy() if torch_res.boxes else np.array([])
+            trt_conf = trt_res.scores
+            if torch_conf.size and trt_conf.size:
+                print(
+                    f"  conf mean (torch/trt): {torch_conf.mean():.4f}/{trt_conf.mean():.4f}"
+                )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Allow processing a directory of images in 3-frame batches so users can run inference over many images without invoking the script repeatedly.
- Preserve the original single-batch mode that accepts exactly three image paths for quick checks.
- Drop or warn about incomplete final batches to maintain the expected `3-in/3-out` engine input shape.

### Description
- Added a mutually-exclusive `--img-dir` argument to `demo_infer_trt.py` and `validate_vs_torch.py` alongside the existing `--img` (3 paths) option.
- Implemented `load_images_from_dir`, `chunked` helpers and per-batch loops to load images in groups of 3 and call `infer_3in3out` for each batch, and print per-batch summaries.
- Emit a warning and drop the last partial batch when the number of images in the folder is not a multiple of 3 to keep batch size consistent with the TRT engine.
- Updated `README.md` to document `--img-dir` usage examples for both demo and validation commands.

### Testing
- No automated tests were executed for this change.
- Basic manual checks performed by running repository commands (no CI/test harness was invoked).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696373f9cc2c8323b7203cf31e09ac08)